### PR TITLE
Wrap service parameters into single quotes to avoid SF4 warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,33 @@
 {
-    "name": "duxet/json_spec",
-    "description": "Easily handle JSON Structures with PhpSpec and Behat",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Sergey Protko",
-            "email": "fesors@gmail.com"
-        }
-    ],
-    "minimum-stability": "stable",
-    "autoload": {
-        "psr-4": {
-          "JsonSpec\\": "src/"
-        }
-    },
-    "config": {
-        "bin-dir": "bin"
-    },
-    "require": {
-        "php": ">=5.4.0",
-        "fesor/json_matcher": "~0.2.1"
-    },
-    "require-dev": {
-        "phpspec/phpspec": "2.1.*@dev",
-        "behat/behat": "~3.0.13@stable",
-        "fabpot/php-cs-fixer": "~0.5"
-    },
-    "conflict": {
-        "behat/behat": "<3.0.13"
+  "name": "rodgermd/json_spec",
+  "description": "Fork of duxet/json_spec. Easily handle JSON Structures with PhpSpec and Behat",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Sergey Protko",
+      "email": "fesors@gmail.com"
     }
+  ],
+  "minimum-stability": "stable",
+  "autoload": {
+    "psr-4": {
+      "JsonSpec\\": "src/"
+    }
+  },
+  "config": {
+    "bin-dir": "bin"
+  },
+  "require": {
+    "php": ">=5.4.0",
+    "fesor/json_matcher": "~0.2.1"
+  },
+  "require-dev": {
+    "phpspec/phpspec": "2.1.*@dev",
+    "behat/behat": "~3.0.13@stable",
+    "fabpot/php-cs-fixer": "~0.5"
+  },
+  "conflict": {
+    "behat/behat": "<3.0.13",
+    "duxet/json_spec": "*"
+  }
 }

--- a/src/Behat/Resources/services/mink_integration.yml
+++ b/src/Behat/Resources/services/mink_integration.yml
@@ -1,6 +1,6 @@
 services:
   json_spec.mink_json_provider:
     class: JsonSpec\Behat\JsonProvider\MinkJsonProvider
-    arguments: ["@json_spec.json_holder", "@mink"]
+    arguments: ['@json_spec.json_holder', '@mink']
     tags:
       - { name: event_dispatcher.subscriber, priority: 0 }

--- a/src/Behat/Resources/services/services.yml
+++ b/src/Behat/Resources/services/services.yml
@@ -5,42 +5,42 @@ services:
 
   json_matcher.factory:
     class: Fesor\JsonMatcher\JsonMatcherFactory
-    arguments: ["@json_matcher.json_helper", %json_spec.excluded_keys%]
+    arguments: ['@json_matcher.json_helper', '%json_spec.excluded_keys%']
 
   json_spec.helper.memory_helper:
     class: JsonSpec\Behat\Helper\MemoryHelper
 
   json_spec.helper.json_loader:
     class: JsonSpec\JsonLoader
-    arguments: [%json_spec.json_directory%]
+    arguments: ['%json_spec.json_directory%']
 
   json_spec.json_holder:
     class: JsonSpec\Behat\JsonProvider\JsonHolder
 
   json_spec.memory_helper_aware_initializer:
     class: JsonSpec\Behat\Context\Initializer\MemoryHelperAwareInitializer
-    arguments: ["@json_spec.helper.memory_helper"]
+    arguments: ['@json_spec.helper.memory_helper']
     tags:
       - {name: context.initializer}
 
   json_spec.json_holder_aware_initializer:
       class: JsonSpec\Behat\Context\Initializer\JsonHolderAwareInitializer
-      arguments: ["@json_spec.json_holder"]
+      arguments: ['@json_spec.json_holder']
       tags:
         - {name: context.initializer}
 
   json_spec.json_matcher_aware_initializer:
       class: JsonSpec\Behat\Context\Initializer\JsonMatcherAwareInitializer
-      arguments: ["@json_matcher.factory"]
+      arguments: ['@json_matcher.factory']
       tags:
         - {name: context.initializer}
 
   json_spec.dependency_resolver:
     class: JsonSpec\Behat\Context\ArgumentResolver\DependencyResolver
     arguments:
-     - "@json_matcher.factory"
-     - "@json_spec.helper.json_loader"
-     - "@json_matcher.json_helper"
+     - '@json_matcher.factory'
+     - '@json_spec.helper.json_loader'
+     - '@json_matcher.json_helper'
     tags:
       - {name: context.argument_resolver}
 


### PR DESCRIPTION
Service parameters must be enclosed in single or double quotes in SF4

![image](https://user-images.githubusercontent.com/1067518/37035096-0dd677f4-2154-11e8-9c23-f587a2853011.png)
